### PR TITLE
add junit/ to gitignore and fix ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         - name: Install dependencies
           run: |
             pip install --upgrade pip  
-            pip install .[dev]
+            pip install '.[dev]'
         - name: Flake8
           run: flake8 src/
         - name: Black

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+junit/
 
 # Translations
 *.mo


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

1. fix ci.yml
```
(env) % pip install .[dev]  
zsh: no matches found: .[dev]
```
vs
```
(env) % pip install '.[dev]'
Processing ...
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
```

2. git ignore `junit/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
