### PR TITLE
In concurrent.futures.ThreadPoolExecutor set max_workers correctly.

### DIFF
--- a/src/agenteval/plan/plan.py
+++ b/src/agenteval/plan/plan.py
@@ -179,7 +179,7 @@ class Plan(BaseModel):
 
     def _run_concurrent(self):
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self._num_tests
+            max_workers=self._num_threads
         ) as executor:
             futures = [
                 executor.submit(self._run_test, test) for test in self._test_suite


### PR DESCRIPTION
*Issue #, if available: none*

*Description of changes:*
Fixes bug in class `Plan`. Method `_run_concurrent` was incorrectly setting `max_workers` to `_num_tests`. This is fixed to correctly set it to `_num_threads`. Consequence of the bug was that the program was ignoring the `--num-threads` CLI option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
