### PR TITLE
Bugfix for throttlingException when calling the InvokeAgent operation

### DIFF
--- a/src/agenteval/plan/plan.py
+++ b/src/agenteval/plan/plan.py
@@ -179,7 +179,7 @@ class Plan(BaseModel):
 
     def _run_concurrent(self):
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self._num_tests
+            max_workers=self._num_threads
         ) as executor:
             futures = [
                 executor.submit(self._run_test, test) for test in self._test_suite

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -2,8 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import uuid
+import time
+import random
+from botocore.exceptions import ClientError
 
 from agenteval.targets import Boto3Target, TargetResponse
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 _SERVICE_NAME = "bedrock-agent-runtime"
 
@@ -25,35 +32,62 @@ class BedrockAgentTarget(Boto3Target):
         self._session_id: str = str(uuid.uuid4())
 
     def invoke(self, prompt: str) -> TargetResponse:
-        """Invoke the target with a prompt.
-
-        Args:
-            prompt (str): The prompt as a string.
-
-        Returns:
-            TargetResponse
-        """
-        args = {
-            "agentId": self._bedrock_agent_id,
-            "agentAliasId": self._bedrock_agent_alias_id,
-            "sessionId": self._session_id,
-            "inputText": prompt,
-            "enableTrace": True,
-        }
-
-        response = self.boto3_client.invoke_agent(**args)
-
-        stream = response["completion"]
         completion = ""
         trace_data = []
 
-        for event in stream:
-            chunk = event.get("chunk")
-            event_trace = event.get("trace")
-            if chunk:
-                completion += chunk.get("bytes").decode()
-            if event_trace:
-                trace_data.append(event_trace.get("trace"))
+        back_off = 0.01  # In seconds.
+        done = False
+        while not done:
+            try:
+                args = {
+                    "agentId": self._bedrock_agent_id,
+                    "agentAliasId": self._bedrock_agent_alias_id,
+                    "sessionId": self._session_id,
+                    "inputText": prompt,
+                    "enableTrace": True,
+                }
+                response = self.boto3_client.invoke_agent(**args)
+                stream = response["completion"]
+
+                completion = ""
+                trace_data = []
+
+                for event in stream:
+                    chunk = event.get("chunk")
+                    event_trace = event.get("trace")
+
+                    if chunk:
+                        completion += chunk.get("bytes").decode()
+                    if event_trace:
+                        trace_data.append(event_trace.get("trace"))
+
+                if back_off > 0.01:
+                    logger.debug(
+                        f"BedrockAgentTarget.invoke, success after backoff. back_off={back_off}"
+                    )
+                done = True
+
+            except ClientError as exception_obj:
+                error_code = exception_obj.response["Error"]["Code"]
+                if error_code == "throttlingException":
+                    logger.debug(
+                        f"BedrockAgentTarget.invoke, throttle. error_code={error_code}, back_off={back_off}"
+                    )
+                    time.sleep(
+                        back_off
+                        * random.uniform(
+                            1, 2
+                        )  # Random backoff between back_off and 2x back_off seconds.
+                    )
+                    back_off *= 2  # Exponential backoff.
+
+                else:
+                    logger.warning(
+                        f"BedrockAgentTarget.invoke, unexpected error. error_code={error_code}"
+                    )
+                    return TargetResponse(
+                        response=completion, data={"bedrock_agent_trace": trace_data}
+                    )
 
         return TargetResponse(
             response=completion, data={"bedrock_agent_trace": trace_data}


### PR DESCRIPTION
*Issue #64: throttlingException when calling the InvokeAgent operation*

*Description of changes:*

In Bedrock Agent `target.py` program. Try/Except and exponential backoff logic implemented to overcome the Bedrock Agent throttling problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
