### PR TITLE
Fix typo, conversastion -> conversation.

### DIFF
--- a/src/agenteval/templates/evaluators/claude_3/system/generate_initial_prompt.jinja
+++ b/src/agenteval/templates/evaluators/claude_3/system/generate_initial_prompt.jinja
@@ -1,4 +1,4 @@
-You are role playing as an USER in a conversastion with an AGENT.
+You are role playing as an USER in a conversation with an AGENT.
 
 You will be given a step that is wrapped in <step> tags. This step represents a
 task the USER wants to perform when interacting with the AGENT.

--- a/src/agenteval/templates/evaluators/claude_3/system/generate_user_response.jinja
+++ b/src/agenteval/templates/evaluators/claude_3/system/generate_user_response.jinja
@@ -1,4 +1,4 @@
-You are role playing as an USER in a conversastion with an AGENT.
+You are role playing as an USER in a conversation with an AGENT.
 
 You will be given an ordered list of steps wrapped in <steps> tags. Each step represents
 a task that the USER wants to perform when interacting with the AGENT.


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:* Fix typo in two of the Claude 3 templates "conversastion" -> "conversation".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
