### PR TITLE
feat: add support of session attributes for bedrock agent target

### DIFF
--- a/docs/targets/bedrock_agents.md
+++ b/docs/targets/bedrock_agents.md
@@ -18,7 +18,7 @@ target:
   bedrock_session_attributes:
     first_name: user-name
   bedrock_prompt_session_attributes:
-    time: current-time
+    timezone: user-timezone
 ```
 
 `bedrock_agent_id` *(string)*
@@ -32,3 +32,23 @@ The unique identifier of the Bedrock agent.
 The alias of the Bedrock agent.
 
 ---
+
+`bedrock_session_attributes`  *(map; optional)*
+
+The attributes that persist over a session between a user and agent, with the same sessionId belong to the same session, as long as the session time limit (the idleSessionTTLinSeconds) has not been surpassed. For example:
+
+```yaml
+bedrock_session_attributes:
+  first_name: user-name
+```
+
+---
+
+`bedrock_prompt_session_attributes`  *(map; optional)*
+
+The attributes that persist over a single call of InvokeAgent. For example:
+
+```yaml
+bedrock_prompt_session_attributes:
+    timezone: user-timezone
+```

--- a/docs/targets/bedrock_agents.md
+++ b/docs/targets/bedrock_agents.md
@@ -15,6 +15,10 @@ target:
   type: bedrock-agent
   bedrock_agent_id: my-agent-id
   bedrock_agent_alias_id: my-alias-id
+  bedrock_session_attributes:
+    first_name: user-name
+  bedrock_prompt_session_attributes:
+    time: current-time
 ```
 
 `bedrock_agent_id` *(string)*

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -11,17 +11,29 @@ _SERVICE_NAME = "bedrock-agent-runtime"
 class BedrockAgentTarget(Boto3Target):
     """A target encapsulating an Amazon Bedrock agent."""
 
-    def __init__(self, bedrock_agent_id: str, bedrock_agent_alias_id: str, **kwargs):
+    def __init__(
+            self,
+            bedrock_agent_id: str,
+            bedrock_agent_alias_id: str,
+            bedrock_session_attributes: dict,
+            bedrock_prompt_session_attributes: dict,
+            **kwargs
+    ):
         """Initialize the target.
 
         Args:
             bedrock_agent_id (str): The unique identifier of the Bedrock agent.
             bedrock_agent_alias_id (str): The alias of the Bedrock agent.
-
+            bedrock_session_attributes (dict): The dictionary of attributes that persist over a session between a user and agent
+            bedrock_prompt_session_attributes (dict): The dictionary of attributes that persist over a single turn (one InvokeAgent call)
         """
         super().__init__(boto3_service_name=_SERVICE_NAME, **kwargs)
         self._bedrock_agent_id = bedrock_agent_id
         self._bedrock_agent_alias_id = bedrock_agent_alias_id
+        self._bedrock_session_state = {
+            "sessionAttributes": bedrock_session_attributes,
+            "promptSessionAttributes": bedrock_prompt_session_attributes,
+        }
         self._session_id: str = str(uuid.uuid4())
 
     def invoke(self, prompt: str) -> TargetResponse:
@@ -36,6 +48,7 @@ class BedrockAgentTarget(Boto3Target):
         args = {
             "agentId": self._bedrock_agent_id,
             "agentAliasId": self._bedrock_agent_alias_id,
+            "sessionState": self._bedrock_session_state,
             "sessionId": self._session_id,
             "inputText": prompt,
             "enableTrace": True,

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -12,12 +12,12 @@ class BedrockAgentTarget(Boto3Target):
     """A target encapsulating an Amazon Bedrock agent."""
 
     def __init__(
-            self,
-            bedrock_agent_id: str,
-            bedrock_agent_alias_id: str,
-            bedrock_session_attributes: dict,
-            bedrock_prompt_session_attributes: dict,
-            **kwargs
+        self,
+        bedrock_agent_id: str,
+        bedrock_agent_alias_id: str,
+        bedrock_session_attributes: dict,
+        bedrock_prompt_session_attributes: dict,
+        **kwargs
     ):
         """Initialize the target.
 

--- a/tests/src/agenteval/targets/bedrock_agent/test_target.py
+++ b/tests/src/agenteval/targets/bedrock_agent/test_target.py
@@ -15,6 +15,8 @@ def bedrock_agent_fixture(mocker):
         bedrock_agent_alias_id="test-alias-id",
         aws_profile="test-profile",
         aws_region="us-west-2",
+        bedrock_session_attributes={"first_name": "user_name"},
+        bedrock_prompt_session_attributes={"timezone": "0"},
     )
 
     return fixture
@@ -48,4 +50,5 @@ class TestBedrockAgentTarget:
         response = bedrock_agent_fixture.invoke("test prompt")
 
         assert response.response == "test completion"
-        assert response.data == {"bedrock_agent_trace": [{"preProcessingTrace": None}]}
+        assert response.data == {
+            "bedrock_agent_trace": [{"preProcessingTrace": None}]}


### PR DESCRIPTION
*Description of changes:*

For some test cases, the user might need to add the support of session attributes.

