### PR TITLE
Fix test result attribute in summary template

### DIFF
--- a/src/agenteval/templates/summary/agenteval_summary.md.jinja
+++ b/src/agenteval/templates/summary/agenteval_summary.md.jinja
@@ -11,13 +11,13 @@ This document provides a summary of the tests executed by Agent Evaluation.
 ---
 ## Tests
 {% for test, result in zip(tests, results) -%}
-- [{% if result.success %}🟢{% else %}🔴{% endif %} {{ test.name }}](#{{ test.name | replace(' ', '-') }})
+- [{% if result.passed %}🟢{% else %}🔴{% endif %} {{ test.name }}](#{{ test.name | replace(' ', '-') }})
 {% endfor %}
 
 ---
 
 {% for test, result in zip(tests, results) -%}
-## <a id={{ test.name | replace(' ', '-') }}></a>{% if result.success %}🟢{% else %}🔴{% endif %} {{ test.name }}
+## <a id={{ test.name | replace(' ', '-') }}></a>{% if result.passed %}🟢{% else %}🔴{% endif %} {{ test.name }}
 
 **Steps**
 {% for step in test.steps -%}


### PR DESCRIPTION
*Issue #67*

*Description of changes:*

* `success` is not an attribute of the [`TestResult`](https://github.com/awslabs/agent-evaluation/blob/83a51af4d6f84469c0081aaf28537857087f1bfd/src/agenteval/test/test_result.py#L26) object. Replace it with `passed`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
