### PR TITLE
89 bedrock agent required arguments documented as optional

### DIFF
--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -3,6 +3,7 @@
 
 import uuid
 from typing import Optional
+
 from agenteval.targets import Boto3Target, TargetResponse
 
 _SERVICE_NAME = "bedrock-agent-runtime"
@@ -12,12 +13,12 @@ class BedrockAgentTarget(Boto3Target):
     """A target encapsulating an Amazon Bedrock agent."""
 
     def __init__(
-            self,
-            bedrock_agent_id: str,
-            bedrock_agent_alias_id: str,
-            bedrock_session_attributes: Optional[dict] = {},
-            bedrock_prompt_session_attributes: Optional[dict] = {},
-            **kwargs
+        self,
+        bedrock_agent_id: str,
+        bedrock_agent_alias_id: str,
+        bedrock_session_attributes: Optional[dict] = {},
+        bedrock_prompt_session_attributes: Optional[dict] = {},
+        **kwargs
     ):
         """Initialize the target.
 
@@ -34,7 +35,9 @@ class BedrockAgentTarget(Boto3Target):
         if bedrock_session_attributes:
             self._session_state["sessionAttributes"] = bedrock_session_attributes
         if bedrock_prompt_session_attributes:
-            self._session_state["promptSessionAttributes"] = bedrock_prompt_session_attributes
+            self._session_state["promptSessionAttributes"] = (
+                bedrock_prompt_session_attributes
+            )
         self._session_id: str = str(uuid.uuid4())
 
     def invoke(self, prompt: str) -> TargetResponse:

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -32,10 +32,6 @@ class BedrockAgentTarget(Boto3Target):
         self._bedrock_agent_alias_id = bedrock_agent_alias_id
         self.bedrock_session_attributes = bedrock_session_attributes
         self.bedrock_prompt_session_attributes = bedrock_prompt_session_attributes
-        # self._bedrock_session_state = {
-        #     "sessionAttributes": bedrock_session_attributes,
-        #     "promptSessionAttributes": bedrock_prompt_session_attributes,
-        # }
         self._session_id: str = str(uuid.uuid4())
 
     def invoke(self, prompt: str) -> TargetResponse:
@@ -50,7 +46,6 @@ class BedrockAgentTarget(Boto3Target):
         args = {
             "agentId": self._bedrock_agent_id,
             "agentAliasId": self._bedrock_agent_alias_id,
-            # "sessionState": self._bedrock_session_state,
             "sessionId": self._session_id,
             "inputText": prompt,
             "enableTrace": True,

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -31,12 +31,10 @@ class BedrockAgentTarget(Boto3Target):
         self._bedrock_agent_id = bedrock_agent_id
         self._bedrock_agent_alias_id = bedrock_agent_alias_id
         self._session_state = {}
-        if bedrock_session_attributes or bedrock_prompt_session_attributes:
-            self._session_state["sessionState"] = {}
-            if bedrock_session_attributes:
-                self._session_state["sessionState"]["sessionAttributes"] = bedrock_session_attributes
-            if bedrock_prompt_session_attributes:
-                self._session_state["sessionState"]["promptSessionAttributes"] = bedrock_prompt_session_attributes
+        if bedrock_session_attributes:
+            self._session_state["sessionAttributes"] = bedrock_session_attributes
+        if bedrock_prompt_session_attributes:
+            self._session_state["promptSessionAttributes"] = bedrock_prompt_session_attributes
         self._session_id: str = str(uuid.uuid4())
 
     def invoke(self, prompt: str) -> TargetResponse:

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -12,12 +12,12 @@ class BedrockAgentTarget(Boto3Target):
     """A target encapsulating an Amazon Bedrock agent."""
 
     def __init__(
-        self,
-        bedrock_agent_id: str,
-        bedrock_agent_alias_id: str,
-        bedrock_session_attributes: Optional[dict] = {},
-        bedrock_prompt_session_attributes: Optional[dict] = {},
-        **kwargs
+            self,
+            bedrock_agent_id: str,
+            bedrock_agent_alias_id: str,
+            bedrock_session_attributes: Optional[dict] = {},
+            bedrock_prompt_session_attributes: Optional[dict] = {},
+            **kwargs
     ):
         """Initialize the target.
 


### PR DESCRIPTION
*Issue #, if available:*
 #89 Bedrock Agent required arguments documented as optional

*Description of changes:*
The the optional arguments: bedrock_session_attributes and bedrock_prompt_session_attributes (as shown in documentation) were not defined as optional for the Bedrock Agent target, which causes errors when not specifiying these two arguments as part of the agenteval.yml. Updating the target.py for Bedrock Agent to change the two arguments as optional and change the logic for passing to the sessionState as one of the key arguments for agent invokation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
