### PR TITLE
Bugfix Doc target knowledgebase extra character

### DIFF
--- a/docs/targets/bedrock_knowledge_bases.md
+++ b/docs/targets/bedrock_knowledge_bases.md
@@ -12,7 +12,7 @@ The principal must have the following permissions:
 
 ```yaml title="agenteval.yml"
 target:
-  type: bedrock-knowledge-base
+  type: bedrock-knowledgebase
   model_id: my-model-id
   knowledge_base_id: my-kb-id
 ```


### PR DESCRIPTION
*Issue #93 , if available:*

*Description of changes:*

Replaced in the markdown corrected documentation:
`type: bedrock-knowledge-base`
With
`type: bedrock-knowledgebase`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
