### PR TITLE
Add support for KB filtering capability to Bedrock Agent Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Initial release
+
+### Unreleased
+- add support for KB filtering capability to Bedrock Agent Target.

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -18,6 +18,7 @@ class BedrockAgentTarget(Boto3Target):
         bedrock_agent_alias_id: str,
         bedrock_session_attributes: Optional[dict] = {},
         bedrock_prompt_session_attributes: Optional[dict] = {},
+        knowledge_base_configurations: Optional[dict] = {},
         **kwargs
     ):
         """Initialize the target.
@@ -32,6 +33,8 @@ class BedrockAgentTarget(Boto3Target):
         self._bedrock_agent_id = bedrock_agent_id
         self._bedrock_agent_alias_id = bedrock_agent_alias_id
         self._session_state = {}
+        if knowledge_base_configurations:
+            self._session_state["knowledgeBaseConfigurations"] = knowledge_base_configurations
         if bedrock_session_attributes:
             self._session_state["sessionAttributes"] = bedrock_session_attributes
         if bedrock_prompt_session_attributes:

--- a/tests/src/agenteval/targets/bedrock_agent/test_target.py
+++ b/tests/src/agenteval/targets/bedrock_agent/test_target.py
@@ -17,6 +17,7 @@ def bedrock_agent_fixture(mocker):
         aws_region="us-west-2",
         bedrock_session_attributes={"first_name": "user_name"},
         bedrock_prompt_session_attributes={"timezone": "0"},
+        knowledge_base_configurations={}
     )
 
     return fixture


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, The BedrockAgentTarget doesn't seem to support KB filtering capability if I need to apply filters to KB for tests. The agent only uses associated KBs but doesn't apply any filters to vector stores.

The proposed changes adds support for KB filtering capability to BedrockAgentTarget.

I was trying to use this tool but realized that I need add this support as my use case needs KB filters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
