### PR TITLE
fix: build include subpackages without `__init__.py` files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from distutils.core import setup
 
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 
 DIST_NAME = "agent-evaluation"
 VERSION = "0.4.0"
@@ -26,7 +26,7 @@ def read(fname):
 setup(
     name=DIST_NAME,
     version=VERSION,
-    packages=find_packages(where=PACKAGE_DIR),
+    packages=find_namespace_packages(where=PACKAGE_DIR),
     package_dir={"": PACKAGE_DIR},
     package_data=PACKAGE_DATA,
     description=DESCRIPTION,


### PR DESCRIPTION
Builds downloaded from pypi do not include subpackages that omit the `__init__.py` package file.

Simply replaced `find_packages` with `find_namespace_packages` in setup config to fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
