### PR TITLE
Update evaluator_factory.py

### DIFF
--- a/src/agenteval/evaluators/evaluator_factory.py
+++ b/src/agenteval/evaluators/evaluator_factory.py
@@ -17,7 +17,7 @@ from agenteval.targets import BaseTarget
 from agenteval.test import Test
 
 _EVALUATOR_METHOD_MAP = {
-    "canoncial": CanonicalEvaluator,
+    "canonical": CanonicalEvaluator,
 }
 
 _DEFAULT_MODEL_CONFIG_MAP = {


### PR DESCRIPTION
Fixed the typo in the evaluation method from canoncial to canonical. It was generating errors during the test execution.

*Issue #, if available:*

*Description of changes:*
Fixed the typo in the evaluation method from canoncial to canonical. It was generating errors during the test execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
