### PR TITLE
fix: add missing __init__ files for new modules; fix spelling mistake…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1]
+
+- Fix broken module imports for `BedrockModelConfig` and `BedrockRequestHandler`.
+- Fix spelling error in `EvaluatorFactory` evaluator method map and add unit test against the same mistake.
+
 ## [0.4.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,16 @@ This project uses [pytest](https://docs.pytest.org/en/8.2.x/) for unit testing, 
 python -m pytest .
 ```
 
+#### Testing against CLI path
+
+If relevant to the change, confirm that the [CLI path](https://awslabs.github.io/agent-evaluation/cli/) functions as expected.
+
+This can be achieved by:
+
+1. Creating and activate a `venv`
+2. Locally install `agent-evaluation` against your local changes via `pip install -e .`
+3. Run `agenteval` CLI against your local changes.
+
 ## Finding Contributions to Work On
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels, looking for any issues labeled `good first issue` or `help wanted` is a great place to start.
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 DIST_NAME = "agent-evaluation"
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 DESCRIPTION = "A generative AI-powered framework for testing virtual agents."
 AUTHOR = "Amazon Web Services"
 EMAIL = "agent-evaluation-oss-core-team@amazon.com"

--- a/src/agenteval/evaluators/bedrock_request/__init__.py
+++ b/src/agenteval/evaluators/bedrock_request/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .bedrock_request_handler import BedrockRequestHandler
+
+__all__ = ["BedrockRequestHandler"]

--- a/src/agenteval/evaluators/evaluator_factory.py
+++ b/src/agenteval/evaluators/evaluator_factory.py
@@ -17,7 +17,7 @@ from agenteval.targets import BaseTarget
 from agenteval.test import Test
 
 _EVALUATOR_METHOD_MAP = {
-    "canoncial": CanonicalEvaluator,
+    "canonical": CanonicalEvaluator,
 }
 
 _DEFAULT_MODEL_CONFIG_MAP = {

--- a/src/agenteval/evaluators/model_config/__init__.py
+++ b/src/agenteval/evaluators/model_config/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .bedrock_model_config import BedrockModelConfig
+
+__all__ = ["BedrockModelConfig"]


### PR DESCRIPTION
Resolves #106 

In release `0.4.0` two small bugs were introduced that are fixed in this PR. I added also steps in the `CONTRIBUTING` to test the CLI path and a unit test to cover the spelling bug that is fixed.

Since this is a patch, I also included the version bump to `0.4.1` in the same commit.

# Testing

- Unit testing: `python -m pytest .`
- Follow steps added to readme to confirm that CLI works now
