### PR TITLE
Upgrade to Python 3.10-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python-version: ["3.9", "3.10", "3.11", "3.12"]
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
         steps:
         - uses: actions/checkout@v4
         - name: Setup Python ${{ matrix.python-version }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-Agent Evaluation requires `python>=3.9`. Please make sure you have an acceptable version of Python before proceeding.
+Agent Evaluation requires `python>=3.10`. Please make sure you have an acceptable version of Python before proceeding.
 
 To install:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pyyaml~=6.0
 boto3>=1.34.20,<2.0
 click~=8.0
 pydantic>=2.1.0,<3.0
-rich>=13.7.0,<14.0
+rich>=13.7.0,<15.0
 jinja2>=3.1.3,<4.0
 jsonpath-ng>=1.6.1,<2.0

--- a/samples/streamlit_app/README.md
+++ b/samples/streamlit_app/README.md
@@ -6,7 +6,7 @@ This directory provides a Web UI for evaluating and interacting with AI agents u
 
 Before running the demo, ensure that you have the following dependencies installed:
 
-- Python (version 3.9 or later)
+- Python (version 3.10 or later)
 - pip (Python package installer)
 
 ## Deployment

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ AUTHOR = "Amazon Web Services"
 EMAIL = "agent-evaluation-oss-core-team@amazon.com"
 URL = "https://awslabs.github.io/agent-evaluation/"
 PACKAGE_DIR = "src"
-REQUIRES_PYTHON = ">=3.9"
+REQUIRES_PYTHON = ">=3.10"
 PACKAGE_DATA = {
     "": [
         "templates/**/*",
@@ -47,9 +47,9 @@ setup(
         "Topic :: Software Development :: Testing",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )


### PR DESCRIPTION
**Issue #, if available:** #112

**Description of changes:**

I **don't** think this change is urgent to merge by itself, but my IDE is bugging me about it so looking for feedback on whether we're keen to 1/ build feature updates on top of py3.10 for next release (i.e. including this commit), or 2/ focus on reverting typing notations to un-break py3.9.

Changes included:

- Bumped our specified Python dependency to 3.10+ everywhere
- Added 3.13 to the CI builds for testing
- Dependency `rich` also has a new major version 14 released, and I can't find any changes that are breaking for our purpose, so broadened our dep range on it to cover both v13 & v14

**Testing:**

Done basic tests, but not as much as I'd like. Marking this PR as draft since looking for feedback but not necessarily pushing for merge+release yet.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
