### PR TITLE
Fixed intermittent pydantic validation error in canonical evaluator

### DIFF
--- a/src/agenteval/evaluators/canonical/evaluator.py
+++ b/src/agenteval/evaluators/canonical/evaluator.py
@@ -87,7 +87,7 @@ class CanonicalEvaluator(BaseEvaluator):
         for e in element_names:
             pattern = rf"<{e}>(.*?)</{e}>"
             match = re.search(pattern, xml_data, re.DOTALL)
-            content.append(match.group(1).strip() if match else None)
+            content.append(match.group(1).strip() if match else "")
         return tuple(content)
 
     def _generate(

--- a/tests/src/agenteval/evaluators/canonical/test_evaluator.py
+++ b/tests/src/agenteval/evaluators/canonical/test_evaluator.py
@@ -47,7 +47,7 @@ class TestCanonical:
         "xml_data,element_names,expected",
         [
             ("<response>test response</response>", ["response"], ("test response",)),
-            ("<response>test response</response>", ["test1", "test2"], (None, None)),
+            ("<response>test response</response>", ["test1", "test2"], ("", "")),
             (
                 "<response>test response</response>\n<thinking>test reasoning</thinking>",
                 ["response", "thinking"],
@@ -57,6 +57,12 @@ class TestCanonical:
                 "<response>test response</response><thinking>test reasoning</thinking>",
                 ["response", "thinking"],
                 ("test response", "test reasoning"),
+            ),
+            # Test case for the bug fix: missing thinking tags should return empty string, not None
+            (
+                "<response>test response</response>",
+                ["response", "thinking"],
+                ("test response", ""),
             ),
         ],
     )


### PR DESCRIPTION
The _extract_content_from_xml method in the canonical evaluator was returning None for missing XML elements.
When the evaluator's LLM didn't include `<thinking></thinking>` tags in its response, this caused a pydantic validation
error because TestResult.reasoning expects a string, not None.

Should resolve #98 - certainly resolved that bug for me. I went from experiencing it 30% of the time to not at all.

### Changes made
Changed line 90 in src/agenteval/evaluators/canonical/evaluator.py:

#### Before:
```py
content.append(match.group(1).strip() if match else None)
```

#### After:
```py
content.append(match.group(1).strip() if match else "")
```

### Tests Updated
- Updated existing test case that expected `(None, None)` to expect `("", "")`
- Added new test case specifically for the missing `<thinking>` tags scenario that was causing the bug

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
